### PR TITLE
ビルド時のエラーを解消する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## 概要
TypeScript 6.0 で compilerOptions.target の es5 が非推奨となり、ビルド時の型チェックで失敗していたため、TypeScript の target 設定を見直しました。

## 背景
TypeScript 6.0 では古い JavaScript 実行環境向けの一部設定が段階的に非推奨化されており、target=es5 もその対象になっています。
今回のエラーは、この非推奨設定がビルド時の型チェックで検出されたことにより発生していました。
このまま維持すると将来の TypeScript 7.0 で設定自体が動作しなくなる見込みのため、現行の実行環境に合わせて target を更新しています。

## 変更内容
- tsconfig.json の compilerOptions.target を es5 から es2017 に変更

## 確認内容
- npx tsc --noEmit --pretty false
- npm run lint は既存の next lint スクリプト解釈問題により別件で失敗することを確認

Resolves #1056