### PR TITLE
コンテナのレイアウトを揃える

### DIFF
--- a/components/blog-client.tsx
+++ b/components/blog-client.tsx
@@ -13,7 +13,7 @@ export default function BlogClient({ allPostsData, years }: BlogProps) {
   }
 
   return (
-    <div className="hero-body container is-block">
+    <div className="hero-body container is-max-desktop">
       <section>
         <nav className="pagination mb-2" role="navigation">
           <ul className="pagination-list">

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({ children, activeTab }: Props) {
     <section className="hero is-fullheight">
       <div className="hero-head">
         <header className="navbar">
-          <div className="container">
+          <div className="container is-max-desktop">
             <div className="navbar-brand">
               <div className="navbar-item is-size-6">
                 <Link href="/" className="has-text-dark">
@@ -28,7 +28,7 @@ export default function Layout({ children, activeTab }: Props) {
       <div className="hero-foot">
         <footer>
           <nav className="tabs is-boxed is-fullwidth">
-            <div className="container">
+            <div className="container is-max-desktop">
               <ul>
                 <li className={activeTab === 'Profile' ? 'is-active' : ''}>
                   <Link href="/profile">Profile</Link>

--- a/components/news-client.tsx
+++ b/components/news-client.tsx
@@ -12,7 +12,7 @@ export default function NewsClient({ allNewsData, years }: NewsProps) {
   }
 
   return (
-    <div className="hero-body container is-block">
+    <div className="hero-body container is-max-desktop">
       <section>
         <nav className="pagination mb-2" role="navigation">
           <ul className="pagination-list">


### PR DESCRIPTION
## 概要

- ヘッダーとフッターのコンテナ幅を本文と同じ最大幅に統一しました
- Blog一覧とNews一覧のコンテナ幅を詳細画面・他画面と揃えました

## 背景・影響

コンテナの幅指定が画面ごとに異なっていたため、画面遷移時に左右位置がずれていました。全画面で `is-max-desktop` を使用することで、広い画面でもレイアウトがぶれないようにしています。

## 確認

- `npm run lint`
- `npx tsc --noEmit`
- 幅1440pxでBlog一覧・Blog詳細・News・Profile・Contactのヘッダー、本文、フッターが同じ左位置・幅になることを確認

Resolves #1127