### PR TITLE
ヘッダータイトルの表示を調整する

### DIFF
--- a/components/layout.module.scss
+++ b/components/layout.module.scss
@@ -1,0 +1,6 @@
+.siteTitle {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  letter-spacing: 0.02em;
+}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import styles from './layout.module.scss';
 
 interface Props {
   readonly children: ReactNode;
@@ -14,12 +15,10 @@ export default function Layout({ children, activeTab }: Props) {
       <div className="hero-head">
         <header className="navbar">
           <div className="container is-max-desktop">
-            <div className="navbar-brand">
-              <div className="navbar-item is-size-6">
-                <Link href="/" className="has-text-dark">
-                  Hiro&apos;s Official Website
-                </Link>
-              </div>
+            <div className={`${styles.siteTitle} navbar-item is-size-6`}>
+              <Link href="/" className="has-text-dark">
+                Hiro&apos;s Official Website
+              </Link>
             </div>
           </div>
         </header>


### PR DESCRIPTION
## 概要

- ヘッダータイトルをコンテナの中央に配置しました
- 中央の短歌とフッターナビに揃えて、画面全体の視覚的な軸を統一しました
- デスクトップとスマートフォンの両方で中央配置を維持する専用スタイルを追加しました
- 英字タイトルに控えめな字間を設定しました

## 影響

ヘッダータイトルの表示位置と文字組みのみ変更します。リンク先や他のナビゲーション動作への影響はありません。

## 確認

- `npm run lint`
- ローカル画面確認（1280×720、390×844）
- `npm run build`（コンパイル・型チェック成功後、既存の `/blog/mokuhyou2022` プリレンダリングエラーで停止）

Resolves #1129